### PR TITLE
Fix DLL exports when compiling with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.0)
 
 project (libccsds VERSION 1.0)
 
+if(MSVC)
+    # Export all symbols in DLL - Could use __declspec(dllexport) if need to be
+    # more selective
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 file(GLOB_RECURSE CCSDS_CPPS src/*.cpp)
 
 add_library(ccsds SHARED ${CCSDS_CPPS})


### PR DESCRIPTION
This PR ensures symbols are exported when compiling a DLL with MSVC.